### PR TITLE
Allow environment variable substitution in paths

### DIFF
--- a/config.go
+++ b/config.go
@@ -354,6 +354,30 @@ func (c *ConfigEntry) GetString(key string, defValue string) string {
 	return defValue
 }
 
+//get the value of key as string and attempt to parse it with StringExpression
+func (c *ConfigEntry) GetStringExpression(key string, defValue string) string {
+	s := c.GetString(key, defValue)
+	if s == "" {
+		return s
+	}
+
+	result, err := NewStringExpression("program_name", c.GetProgramName(),
+		"process_num", c.GetString("process_num", "0"),
+		"group_name", c.GetGroupName(),
+		"here", c.ConfigDir).Eval(s)
+
+	if err != nil {
+		log.WithFields(log.Fields{
+			log.ErrorKey: err,
+			"program":    c.GetProgramName(),
+			"key":        key,
+		}).Warn("unable to parse expression")
+		return s
+	}
+
+	return result
+}
+
 func (c *ConfigEntry) GetStringArray(key string, sep string) []string {
 	s, ok := c.keyValues[key]
 

--- a/process.go
+++ b/process.go
@@ -295,7 +295,7 @@ func (p *Process) getExitCodes() []int {
 }
 
 func (p *Process) run(runCond *sync.Cond) {
-	args, err := parseCommand(p.config.GetString("command", ""))
+	args, err := parseCommand(p.config.GetStringExpression("command", ""))
 
 	if err != nil {
 		log.Error("the command is empty string")
@@ -416,7 +416,7 @@ func (p *Process) setEnv() {
 }
 
 func (p *Process) setDir() {
-	dir := p.config.GetString("directory", "")
+	dir := p.config.GetStringExpression("directory", "")
 	if dir != "" {
 		p.cmd.Dir = dir
 		fmt.Printf("Directory has been set to: %s\n", dir)
@@ -425,7 +425,7 @@ func (p *Process) setDir() {
 
 func (p *Process) setLog() {
 	if p.config.IsProgram() {
-		p.stdoutLog = p.createLogger(p.config.GetString("stdout_logfile", ""),
+		p.stdoutLog = p.createLogger(p.config.GetStringExpression("stdout_logfile", ""),
 			int64(p.config.GetBytes("stdout_logfile_maxbytes", 50*1024*1024)),
 			p.config.GetInt("stdout_logfile_backups", 10),
 			p.createStdoutLogEventEmitter())
@@ -444,7 +444,7 @@ func (p *Process) setLog() {
 		if p.config.GetBool("redirect_stderr", false) {
 			p.stderrLog = p.stdoutLog
 		} else {
-			p.stderrLog = p.createLogger(p.config.GetString("stderr_logfile", ""),
+			p.stderrLog = p.createLogger(p.config.GetStringExpression("stderr_logfile", ""),
 				int64(p.config.GetBytes("stderr_logfile_maxbytes", 50*1024*1024)),
 				p.config.GetInt("stderr_logfile_backups", 10),
 				p.createStderrLogEventEmitter())


### PR DESCRIPTION
It might not seem like much, but if I want to share a config with coworkers, not all of them have the same GOPATH

For example

```
[program:balancer]
command=balancer --debug
directory=%(ENV_GOPATH)s/src/git.lab/usvc/balancer
stdout_logfile=log/balancer.log
redirect_stderr=true
stdout_logfile_maxbytes=1MB
```