### PR TITLE
Clear all logs file should stop at the max rotated file number

### DIFF
--- a/log.go
+++ b/log.go
@@ -147,17 +147,17 @@ func (l *FileLogger) ClearAllLogFile() error {
 	l.locker.Lock()
 	defer l.locker.Unlock()
 
-	for i := 0; i < l.backups; i++ {
+	for i := 0; i < l.backups && i <= l.curRotate; i++ {
 		logFile := l.getLogFileName(i)
 		err := os.Remove(logFile)
 		if err != nil {
-			return NewFault(FAILED, "FAILED")
+			return NewFault(FAILED, err.Error())
 		}
 	}
 	l.curRotate = 0
 	err := l.openFile(true)
 	if err != nil {
-		return NewFault(FAILED, "FAILED")
+		return NewFault(FAILED, err.Error())
 	}
 	return nil
 }


### PR DESCRIPTION
Daemon want to delete file from 0 to max backups, but if rotate haven't been processed, it fails

> supervisor> clear worker
error: <type 'exceptions.ValueError'>, Unknown result code -32500 for worker: file: /usr/lib/python2.7/dist-packages/supervisor/supervisorctl.py line: 988

Also, returning the correct error to be more transparent.