### PR TITLE
Environment variable doesn't need to be escaped

### DIFF
--- a/config.go
+++ b/config.go
@@ -298,7 +298,7 @@ func (c *ConfigEntry) GetEnv(key string) []string {
 					i++
 				}
 				if i < n {
-					env = append(env, fmt.Sprintf("%s=\"%s\"", key, value[start+1:i]))
+					env = append(env, fmt.Sprintf("%s=%s", key, value[start+1:i]))
 				}
 				if i+1 < n && value[i+1] == ',' {
 					start = i + 2
@@ -310,10 +310,10 @@ func (c *ConfigEntry) GetEnv(key string) []string {
 					i++
 				}
 				if i < n {
-					env = append(env, fmt.Sprintf("%s=\"%s\"", key, value[start:i]))
+					env = append(env, fmt.Sprintf("%s=%s", key, value[start:i]))
 					start = i + 1
 				} else {
-					env = append(env, fmt.Sprintf("%s=\"%s\"", key, value[start:]))
+					env = append(env, fmt.Sprintf("%s=%s", key, value[start:]))
 					break
 				}
 			}

--- a/config_test.go
+++ b/config_test.go
@@ -87,14 +87,14 @@ func TestGetEnvValueFromConfig(t *testing.T) {
 	config, _ := parse([]byte("[program:test]\na=A=\"env1\",B=env2"))
 	entry := config.GetProgram("test")
 	envs := entry.GetEnv("a")
-	if len(envs) != 2 || envs[0] != "A=\"env1\"" || envs[1] != "B=\"env2\"" {
+	if len(envs) != 2 || envs[0] != "A=env1" || envs[1] != "B=env2" {
 		t.Error("Fail to get env value")
 	}
 
 	config, _ = parse([]byte("[program:test]\na=A=env1,B=\"env2\""))
 	entry = config.GetProgram("test")
 	envs = entry.GetEnv("a")
-	if len(envs) != 2 || envs[0] != "A=\"env1\"" || envs[1] != "B=\"env2\"" {
+	if len(envs) != 2 || envs[0] != "A=env1" || envs[1] != "B=env2" {
 		t.Error("Fail to get env value")
 	}
 


### PR DESCRIPTION
Hey!

Practical example of the bug fix here:

```sh
rbeuque$ TEST="hello world" sleep 220 &
rbeuque$ xargs -n 1 -0 < /proc/6872/environ | head
TEST=hello world
```

No quotes with normal bash behaviour, but we have some with supervisord