### PR TITLE
validate XmlRPCClient response code

### DIFF
--- a/xmlrpc-client.go
+++ b/xmlrpc-client.go
@@ -43,6 +43,12 @@ func (r *XmlRPCClient) GetVersion() (reply VersionReply, err error) {
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode/100 != 2 {
+		fmt.Println("Bad Response:", resp.Status)
+		err = fmt.Errorf("Response code is NOT 2xx")
+		return
+	}
+
 	err = xml.DecodeClientResponse(resp.Body, &reply)
 
 	return
@@ -57,6 +63,12 @@ func (r *XmlRPCClient) GetAllProcessInfo() (reply AllProcessInfoReply, err error
 		return
 	}
 	defer resp.Body.Close()
+
+	if resp.StatusCode/100 != 2 {
+		fmt.Println("Bad Response:", resp.Status)
+		err = fmt.Errorf("Response code is NOT 2xx")
+		return
+	}
 
 	err = xml.DecodeClientResponse(resp.Body, &reply)
 
@@ -78,6 +90,12 @@ func (r *XmlRPCClient) ChangeProcessState(change string, processName string) (re
 	}
 	defer resp.Body.Close()
 
+	if resp.StatusCode/100 != 2 {
+		fmt.Println("Bad Response:", resp.Status)
+		err = fmt.Errorf("Response code is NOT 2xx")
+		return
+	}
+
 	err = xml.DecodeClientResponse(resp.Body, &reply)
 
 	return
@@ -92,6 +110,12 @@ func (r *XmlRPCClient) Shutdown() (reply ShutdownReply, err error) {
 		return
 	}
 	defer resp.Body.Close()
+
+	if resp.StatusCode/100 != 2 {
+		fmt.Println("Bad Response:", resp.Status)
+		err = fmt.Errorf("Response code is NOT 2xx")
+		return
+	}
 
 	err = xml.DecodeClientResponse(resp.Body, &reply)
 


### PR DESCRIPTION
If XmlRPCClient response code is not 2xx, return the error message.

eg, if request without `username` & `password`, 401 will be returned.
```
# supervisord ctl status
Bad Response code: 401
```