### PR TITLE
Adding .travis.yml and .goreleaser.yml

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,10 @@
+build:
+  binary: supervisord
+  goos:
+    - linux
+  goarch:
+    - amd64
+archive:
+  format: binary
+snapshot:
+  name_template: "{{.Commit}}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: go
+
+go:
+- 1.9.2
+
+after_success:
+  - test -n "$TRAVIS_TAG" && curl -sL https://git.io/goreleaser | bash


### PR DESCRIPTION
Using travis-ci to auto-launch go test on every pull-requests that are
issued on repository.

after-success part is only trigger if commit is tagged on repository
with a version, so we can auto-release a binary with goreleaser on
GitHub releases part of the repository.

Exemple here for release that have been pushed by travis-ci: https://github.com/Rbeuque74/supervisord/releases