### PR TITLE
Imported package names should be lowercase

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,7 +2,7 @@
 
 
 [[projects]]
-  name = "github.com/Sirupsen/logrus"
+  name = "github.com/sirupsen/logrus"
   packages = ["."]
   revision = "a3f95b5c423586578a4e099b11a46c2479628cac"
   version = "1.0.2"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -22,7 +22,7 @@
 
 
 [[constraint]]
-  name = "github.com/Sirupsen/logrus"
+  name = "github.com/sirupsen/logrus"
   version = "1.0.2"
 
 [[constraint]]

--- a/config/config.go
+++ b/config/config.go
@@ -10,7 +10,7 @@ import (
 	"strconv"
 	"strings"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	ini "github.com/ochinchina/go-ini"
 )
 

--- a/daemonize.go
+++ b/daemonize.go
@@ -3,7 +3,7 @@
 package main
 
 import (
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/sevlyar/go-daemon"
 )
 

--- a/events/events.go
+++ b/events/events.go
@@ -5,7 +5,7 @@ import (
 	"bytes"
 	"container/list"
 	"fmt"
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"io"
 	"strconv"
 	"strings"

--- a/main.go
+++ b/main.go
@@ -7,7 +7,7 @@ import (
 	"runtime"
 	"syscall"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/jessevdk/go-flags"
 )
 

--- a/process/process.go
+++ b/process/process.go
@@ -2,7 +2,7 @@ package process
 
 import (
 	"fmt"
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/ochinchina/supervisord/config"
 	"github.com/ochinchina/supervisord/events"
 	"github.com/ochinchina/supervisord/logger"

--- a/process/process_manager.go
+++ b/process/process_manager.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"sync"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/ochinchina/supervisord/config"
 )
 

--- a/signals/signal_windows.go
+++ b/signals/signal_windows.go
@@ -5,7 +5,7 @@ package signals
 import (
 	"errors"
 	"fmt"
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"os"
 	"os/exec"
 	"syscall"

--- a/supervisor.go
+++ b/supervisor.go
@@ -16,7 +16,7 @@ import (
 	"sync"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 const (

--- a/xmlrpc.go
+++ b/xmlrpc.go
@@ -9,7 +9,7 @@ import (
 	"os"
 	"strings"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/gorilla/rpc"
 	"github.com/ochinchina/gorilla-xmlrpc/xml"
 )


### PR DESCRIPTION
According to note in https://github.com/sirupsen/logrus/blob/master/README.md, all imported package names should be lowercase to avoid issues when adding them via `dep` command