### PR TITLE
Update config.go

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -319,7 +319,7 @@ func (c *ConfigEntry) GetEnv(key string) []string {
 					i++
 				}
 				if i < n {
-					env = append(env, fmt.Sprintf("%s=%s", key, value[start+1:i]))
+					env = append(env, fmt.Sprintf("%s=%s", strings.TrimSpace(key), strings.TrimSpace(value[start+1:i])))
 				}
 				if i+1 < n && value[i+1] == ',' {
 					start = i + 2
@@ -331,10 +331,10 @@ func (c *ConfigEntry) GetEnv(key string) []string {
 					i++
 				}
 				if i < n {
-					env = append(env, fmt.Sprintf("%s=%s", key, value[start:i]))
+					env = append(env, fmt.Sprintf("%s=%s", strings.TrimSpace(key), strings.TrimSpace(value[start:i])))
 					start = i + 1
 				} else {
-					env = append(env, fmt.Sprintf("%s=%s", key, value[start:]))
+					env = append(env, fmt.Sprintf("%s=%s", strings.TrimSpace(key), strings.TrimSpace(value[start:])))
 					break
 				}
 			}


### PR DESCRIPTION
取配置文件的环境变量时，增加去除首尾空格的处理，以兼容python版superverd的配置文件，当前是不兼容存在空格的。例如：environment=GOPATH="/home/git/goapp", HOME="/home/git", USER="git"