### PR TITLE
Fix: remove program from config without 'program:' prefix

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -547,6 +547,6 @@ func (c *Config) String() string {
 }
 
 func (c *Config) RemoveProgram(programName string) {
-	delete(c.entries, fmt.Sprintf("program:%s", programName))
+	delete(c.entries, programName)
 	c.ProgramGroup.Remove(programName)
 }


### PR DESCRIPTION
Fix a fatal bug: remove program from config just by its program name without 'program:' prefix