### PR TITLE
add missed method `TailProcessStderrLog`

### DIFF
--- a/supervisor.go
+++ b/supervisor.go
@@ -593,6 +593,16 @@ func (s *Supervisor) TailProcessStdoutLog(r *http.Request, args *ProcessLogReadI
 	return err
 }
 
+func (s *Supervisor) TailProcessStderrLog(r *http.Request, args *ProcessLogReadInfo, reply *ProcessTailLog) error {
+	proc := s.procMgr.Find(args.Name)
+	if proc == nil {
+		return fmt.Errorf("No such process %s", args.Name)
+	}
+	var err error
+	reply.LogData, reply.Offset, reply.Overflow, err = proc.StderrLog.ReadTailLog(int64(args.Offset), int64(args.Length))
+	return err
+}
+
 func (s *Supervisor) ClearProcessLogs(r *http.Request, args *struct{ Name string }, reply *struct{ Success bool }) error {
 	proc := s.procMgr.Find(args.Name)
 	if proc == nil {


### PR DESCRIPTION
add missed method `TailProcessStderrLog` which is already registered in the `xmlrpc.go`