### PR TITLE
add env parse error logs for users' troubleshooting

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -533,12 +533,20 @@ func (c *Config) parseProgram(cfg *ini.Ini) []string {
 					"here", c.GetConfigFileDir())
 				cmd, err := envs.Eval(section.GetValueWithDefault("command", ""))
 				if err != nil {
+					log.WithFields(log.Fields{
+						log.ErrorKey: err,
+						"program":    programName,
+					}).Error("get envs failed")
 					continue
 				}
 				section.Add("command", cmd)
 
 				procName, err := envs.Eval(originalProcName)
 				if err != nil {
+					log.WithFields(log.Fields{
+						log.ErrorKey: err,
+						"program":    programName,
+					}).Error("get envs failed")
 					continue
 				}
 


### PR DESCRIPTION
I've ecountered several times when users have mistakes writing environment vars expressions in supervisord.conf, and the troubleshooting process is annoying and ineffective, I believe we need some log messages here.