### PR TITLE
[fix] do not discard errors

### DIFF
--- a/ctl.go
+++ b/ctl.go
@@ -186,6 +186,7 @@ func (x *CtlCommand) status(rpcc *xmlrpcclient.XMLRPCClient, processes []string)
 	if reply, err := rpcc.GetAllProcessInfo(); err == nil {
 		x.showProcessInfo(&reply, processesMap)
 	} else {
+		fmt.Fprintf(os.Stderr, "%s\n", err)
 		os.Exit(1)
 	}
 }
@@ -245,6 +246,7 @@ func (x *CtlCommand) shutdown(rpcc *xmlrpcclient.XMLRPCClient) {
 			fmt.Printf("Hmmm! Something gone wrong?!\n")
 		}
 	} else {
+		fmt.Fprintf(os.Stderr, "%s\n", err)
 		os.Exit(1)
 	}
 }
@@ -263,6 +265,7 @@ func (x *CtlCommand) reload(rpcc *xmlrpcclient.XMLRPCClient) {
 			fmt.Printf("Removed Groups: %s\n", strings.Join(reply.RemovedGroup, ","))
 		}
 	} else {
+		fmt.Fprintf(os.Stderr, "%s\n", err)
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
Some errors are silently discarded. This should not happen.

Changes:

- exit code for all remote call errors
- print error to stderr