### PR TITLE
修复 如果 startSecs 设置为 0 时，进程将永远是 running 状态

### DIFF
--- a/process/process.go
+++ b/process/process.go
@@ -558,6 +558,7 @@ func (p *Process) run(finishCb func()) {
 		//Set startsec to 0 to indicate that the program needn't stay
 		//running for any particular amount of time.
 		if startSecs <= 0 {
+			atomic.StoreInt32(&monitorExited, 1)
 			log.WithFields(log.Fields{"program": p.GetName()}).Info("success to start program")
 			p.changeStateTo(Running)
 			go finishCbWrapper()


### PR DESCRIPTION
您好，通过使用代码发现如果进程设置 `startSecs = 0` 进程将会无法修改状态，一直卡在 `running`。不知道我这样修改是否符合预期。