### PR TITLE
Fix process_num in command field always parsed as 1

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -545,12 +545,14 @@ func (c *Config) parseProgram(cfg *ini.Ini) []string {
 				originalProcName = procName
 			}
 
+			originalCmd := section.GetValueWithDefault("command", "")
+
 			for i := 1; i <= numProcs; i++ {
 				envs := NewStringExpression("program_name", programName,
 					"process_num", fmt.Sprintf("%d", i),
 					"group_name", c.ProgramGroup.GetGroup(programName, programName),
 					"here", c.GetConfigFileDir())
-				cmd, err := envs.Eval(section.GetValueWithDefault("command", ""))
+				cmd, err := envs.Eval(originalCmd)
 				if err != nil {
 					log.WithFields(log.Fields{
 						log.ErrorKey: err,


### PR DESCRIPTION
The current version has a bug that `%(process_num)d` in command field is always parsed as 1. This is caused by incorrectly set section value of "command" after each parse. This PR fixes this bug.

Signed-off-by: Yilun <zyl.skysniper@gmail.com>