### PR TITLE
Add missing dependencies for building docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
 FROM golang:alpine AS builder
 
-RUN apk add --no-cache --update git
+RUN apk add --no-cache --update git gcc rust
 
-RUN go get -v -u github.com/ochinchina/supervisord
+COPY . /src
+WORKDIR /src
 
-RUN CGO_ENABLED=0 GOOS=linux go build -a -ldflags "-linkmode external -extldflags -static" -o /usr/local/bin/supervisord github.com/ochinchina/supervisord
+RUN GOPROXY=direct GOSUMDB=off CGO_ENABLED=0 go build -a -ldflags "-linkmode external -extldflags -static" -o /usr/local/bin/supervisord github.com/ochinchina/supervisord
 
 FROM scratch
 


### PR DESCRIPTION
Needed to build my own image cause of arm64 support, but the current Dockerfile didn't worked for me.

This changes works fine for me https://github.com/users/shyim/packages/container/package/supervisord

Also, your docker image seems currently out of date. If you need help, let me know 😊 