### PR TITLE
fix: fix run as daemon failed on some tile

### DIFF
--- a/daemonize.go
+++ b/daemonize.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package main
@@ -9,7 +10,7 @@ import (
 
 // Daemonize run this process in daemon mode
 func Daemonize(logfile string, proc func()) {
-	context := daemon.Context{LogFileName: logfile}
+	context := daemon.Context{LogFileName: logfile, PidFileName: "supervisord.pid"}
 
 	child, err := context.Reborn()
 	if err != nil {


### PR DESCRIPTION
fix Unable to run err="readlink /proc/self/exe: no such file or directory" on some system : CentOS release 6.7 
![image](https://user-images.githubusercontent.com/23069203/133557562-13ac171f-33c0-41c2-b831-d09d75e8c38f.png)
