### PR TITLE
use default GOPROXY and GOSUMDB for go build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apk add --no-cache --update git gcc rust
 COPY . /src
 WORKDIR /src
 
-RUN GOPROXY=direct GOSUMDB=off CGO_ENABLED=0 go build -a -ldflags "-linkmode external -extldflags -static" -o /usr/local/bin/supervisord github.com/ochinchina/supervisord
+RUN CGO_ENABLED=0 go build -a -ldflags "-linkmode external -extldflags -static" -o /usr/local/bin/supervisord github.com/ochinchina/supervisord
 
 FROM scratch
 


### PR DESCRIPTION
With the current setting of `GOPROXY=direct`, gopkg.in was directly accessed for downloading go mod packages and that server has been flaky, sometimes returning HTTP 502 messages.

This PR removes override of GOPROXY and GOSUMDB env variables. This will allow `go build` to use the [default proxy provided by google](https://proxy.golang.org/). Using the checksum db to verify the downloaded go mod packages is also just good practice so turning it back on was part of this change.

As a result of using the default proxy provided by google, build times of the docker image should reduce. Previously it took me 41s, but with this change it takes 7s.