### PR TITLE
Rename install_signal and add props to syslogger for Windows build

### DIFF
--- a/logger/log_windows.go
+++ b/logger/log_windows.go
@@ -1,3 +1,4 @@
+//go:build windows || plan9 || nacl
 // +build windows plan9 nacl
 
 package logger
@@ -7,5 +8,5 @@ func NewSysLogger(name string, props map[string]string, logEventEmitter LogEvent
 }
 
 func NewRemoteSysLogger(name string, config string, props map[string]string, logEventEmitter LogEventEmitter) *SysLogger {
-	return NewSysLogger(name, logEventEmitter)
+	return NewSysLogger(name, props, logEventEmitter)
 }

--- a/pidproxy/signal_windows.go
+++ b/pidproxy/signal_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package main
@@ -8,7 +9,7 @@ import (
 	"syscall"
 )
 
-func install_signal(c chan os.Signal) {
+func installSignal(c chan os.Signal) {
 	signal.Notify(c, syscall.SIGTERM,
 		syscall.SIGHUP,
 		syscall.SIGINT,


### PR DESCRIPTION
The installSignal function was named incorrectly causing the build to fail.