### PR TITLE
Rename config entry to restart_file_pattern

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,53 @@
+name: build
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+    release:
+        runs-on: ubuntu-latest
+        steps:
+            -
+                name: Checkout
+                uses: actions/checkout@v2
+                with:
+                    fetch-depth: 0
+            -
+                name: Make github config
+                run: curl -sL https://raw.githubusercontent.com/triole/ghwfe/master/sh/make_github_config.sh | bash
+            -
+                name: Install Go
+                env:
+                    TARGET_FOLDER: /home/runner/.local/go
+                run: curl -sL https://raw.githubusercontent.com/triole/ghwfe/master/sh/go_install.sh | bash
+            -
+                name: Add packages in sub folders to GOROOT
+                env:
+                    GOROOT: /home/runner/.local/go
+                    SOURCE_FOLDER: .
+                run: curl -sL https://raw.githubusercontent.com/triole/ghwfe/master/sh/go_add_sub_packages.sh | bash
+            -
+                name: Build
+                env:
+                    GOROOT: /home/runner/.local/go
+                    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                    # APP_NAME: binary_name
+                    SOURCE_FOLDER: .
+                    # TARGET_FOLDER: build
+                run: curl -sL https://raw.githubusercontent.com/triole/ghwfe/master/sh/go_build.sh | bash
+            -
+                name: Gzip assets
+                env:
+                    # SOURCE_FOLDER: build
+                    # TARGET_FOLDER: /tmp/assets
+                    VERSION_COMMAND: date +%y.%m.%d
+                run: curl -sL https://raw.githubusercontent.com/triole/ghwfe/master/sh/gzip_builds.sh | bash
+            -
+                name: Upload release binaries
+                uses: alexellis/upload-assets@0.3.0
+                env:
+                    GITHUB_TOKEN: ${{ github.token }}
+                with:
+                    asset_paths: '["/tmp/assets/*"]'

--- a/process/process.go
+++ b/process/process.go
@@ -453,7 +453,7 @@ func (p *Process) setProgramRestartChangeMonitor(programPath string) {
 		})
 	}
 	dirMonitor := p.config.GetString("restart_directory_monitor", "")
-	filePattern := p.config.GetString("restart_filePattern", "*")
+	filePattern := p.config.GetString("restart_file_pattern", "*")
 	if dirMonitor != "" {
 		absDir, err := filepath.Abs(dirMonitor)
 		if err != nil {


### PR DESCRIPTION
I was wondering why my restart file pattern did not work and found out that it was because of the difference between documentation and code. I suggest we use `restart_file_pattern` because it is closer to proper English and corresponds to the other restart config entries. Here is my tiny pull request.

There is also an issue mentioning that problem: https://github.com/ochinchina/supervisord/issues/316. I suppose it could be closed when this is merged.