### PR TITLE
Rename config entry to restart_file_pattern

### DIFF
--- a/process/process.go
+++ b/process/process.go
@@ -453,7 +453,7 @@ func (p *Process) setProgramRestartChangeMonitor(programPath string) {
 		})
 	}
 	dirMonitor := p.config.GetString("restart_directory_monitor", "")
-	filePattern := p.config.GetString("restart_filePattern", "*")
+	filePattern := p.config.GetString("restart_file_pattern", "*")
 	if dirMonitor != "" {
 		absDir, err := filepath.Abs(dirMonitor)
 		if err != nil {


### PR DESCRIPTION
I was wondering why my restart file pattern did not work and found out that it was because of the difference between documentation and code. I suggest we use restart_file_pattern because it is closer to proper English and corresponds to the other restart config entries. Here is my tiny pull request.

There is also an issue mentioning that problem: https://github.com/ochinchina/supervisord/issues/316. I suppose it could be closed when this is merged.