### PR TITLE
fix: Changes for multiple groups are not displayed correctly

### DIFF
--- a/xmlrpcclient/xml_processor.go
+++ b/xmlrpcclient/xml_processor.go
@@ -57,19 +57,19 @@ func (xp *XMLPath) String() string {
 // XMLLeafProcessor the XML leaf element process function
 type XMLLeafProcessor func(value string)
 
-// XMLNonLeafProcessor the non-leaf element process function
-type XMLNonLeafProcessor func()
+// XMLSwitchTypeProcessor the switch type process function
+type XMLSwitchTypeProcessor func()
 
 // XMLProcessorManager the xml processor based on the XMLPath
 type XMLProcessorManager struct {
-	leafProcessors    map[string]XMLLeafProcessor
-	nonLeafProcessors map[string]XMLNonLeafProcessor
+	leafProcessors       map[string]XMLLeafProcessor
+	switchTypeProcessors map[string]XMLSwitchTypeProcessor
 }
 
 // NewXMLProcessorManager creates new XMLProcessorManager object
 func NewXMLProcessorManager() *XMLProcessorManager {
 	return &XMLProcessorManager{leafProcessors: make(map[string]XMLLeafProcessor),
-		nonLeafProcessors: make(map[string]XMLNonLeafProcessor)}
+		switchTypeProcessors: make(map[string]XMLSwitchTypeProcessor)}
 }
 
 // AddLeafProcessor adds leaf processor for the xml path
@@ -77,9 +77,9 @@ func (xpm *XMLProcessorManager) AddLeafProcessor(path string, processor XMLLeafP
 	xpm.leafProcessors[path] = processor
 }
 
-// AddNonLeafProcessor adds non-leaf processor for the xml path
-func (xpm *XMLProcessorManager) AddNonLeafProcessor(path string, processor XMLNonLeafProcessor) {
-	xpm.nonLeafProcessors[path] = processor
+// AddSwitchTypeProcessor adds switch type processor for the xml path
+func (xpm *XMLProcessorManager) AddSwitchTypeProcessor(path string, processor XMLSwitchTypeProcessor) {
+	xpm.switchTypeProcessors[path] = processor
 }
 
 // ProcessLeafNode processes leaf element with xml path and its value
@@ -89,9 +89,9 @@ func (xpm *XMLProcessorManager) ProcessLeafNode(path string, data string) {
 	}
 }
 
-// ProcessNonLeafNode processes non-leaf element based on the xml path
-func (xpm *XMLProcessorManager) ProcessNonLeafNode(path string) {
-	if processor, ok := xpm.nonLeafProcessors[path]; ok {
+// ProcessSwitchTypeNode processes switch type based on the xml path
+func (xpm *XMLProcessorManager) ProcessSwitchTypeNode(path string) {
+	if processor, ok := xpm.switchTypeProcessors[path]; ok {
 		processor()
 	}
 }
@@ -119,9 +119,8 @@ func (xpm *XMLProcessorManager) ProcessXML(reader io.Reader) {
 		case xml.EndElement:
 			if curData != nil {
 				xpm.ProcessLeafNode(curPath.String(), string(curData))
-			} else {
-				xpm.ProcessNonLeafNode(curPath.String())
 			}
+			xpm.ProcessSwitchTypeNode(curPath.String())
 			curPath.RemoveLast()
 		}
 	}

--- a/xmlrpcclient/xmlrpc-client.go
+++ b/xmlrpcclient/xmlrpc-client.go
@@ -272,18 +272,11 @@ func (r *XMLRPCClient) ReloadConfig() (reply types.ReloadConfigResult, err error
 	reply.AddedGroup = make([]string, 0)
 	reply.ChangedGroup = make([]string, 0)
 	reply.RemovedGroup = make([]string, 0)
-	i := -1
-	hasValue := false
-	xmlProcMgr.AddNonLeafProcessor("methodResponse/params/param/value/array/data", func() {
-		if hasValue {
-			hasValue = false
-		} else {
-			i++
-		}
+	i := 0
+	xmlProcMgr.AddSwitchTypeProcessor("methodResponse/params/param/value/array/data", func() {
+		i++
 	})
 	xmlProcMgr.AddLeafProcessor("methodResponse/params/param/value/array/data/value", func(value string) {
-		hasValue = true
-		i++
 		switch i {
 		case 0:
 			reply.AddedGroup = append(reply.AddedGroup, value)
@@ -348,7 +341,7 @@ func (r *XMLRPCClient) GetProcessInfo(process string) (reply types.ProcessInfo, 
 
 // StartProcess Start a process
 func (r *XMLRPCClient) StartProcess(process string, wait bool) (reply types.BooleanReply, err error) {
-	ins := struct{
+	ins := struct {
 		Name string
 		Wait bool
 	}{
@@ -376,7 +369,7 @@ func (r *XMLRPCClient) StartProcess(process string, wait bool) (reply types.Bool
 
 // StopProcess Stop a process named by name
 func (r *XMLRPCClient) StopProcess(process string, wait bool) (reply types.BooleanReply, err error) {
-	ins := struct{
+	ins := struct {
 		Name string
 		Wait bool
 	}{
@@ -404,7 +397,7 @@ func (r *XMLRPCClient) StopProcess(process string, wait bool) (reply types.Boole
 
 // StartAllProcesses Start all processes listed in the configuration file
 func (r *XMLRPCClient) StartAllProcesses(wait bool) (reply AllProcStatusInfoReply, err error) {
-	ins := struct{ Wait bool }{ wait }
+	ins := struct{ Wait bool }{wait}
 	r.post("supervisor.startAllProcesses", &ins, func(body io.ReadCloser, procError error) {
 		err = procError
 		if err == nil {
@@ -416,7 +409,7 @@ func (r *XMLRPCClient) StartAllProcesses(wait bool) (reply AllProcStatusInfoRepl
 
 // StopAllProcesses Stop all processes in the process list
 func (r *XMLRPCClient) StopAllProcesses(wait bool) (reply AllProcStatusInfoReply, err error) {
-	ins := struct{ Wait bool }{ wait }
+	ins := struct{ Wait bool }{wait}
 	r.post("supervisor.stopAllProcesses", &ins, func(body io.ReadCloser, procError error) {
 		err = procError
 		if err == nil {


### PR DESCRIPTION
check [this](https://github.com/ZhuzhuNo3/supervisord/raw/test/display_groups_change/supervisord_test.tar.gz) for test.

execute `./run.sh`

```
+ ./tool.sh
+ sleep 3
+ ln -sf ../supervisor_bak/test1.conf ../supervisor_bak/test2.conf ../supervisor_bak/test3.conf ../supervisor_bak/test4.conf ./supervisor/.
+ ./tool.sh reload
Added Groups: test2,test1,test3,test4
+ sleep 3
+ rm -rf ./supervisor/test1.conf ./supervisor/test2.conf ./supervisor/test3.conf
+ ln -sf ../supervisor_bak/test3_change.conf ./supervisor/.
+ ./tool.sh reload
Changed Groups: test3
Removed Groups: test2,test1
+ sleep 3
+ rm -rf ./supervisor/test3_change.conf ./supervisor/test4.conf
+ ln -sf ../supervisor_bak/test1.conf ../supervisor_bak/test2.conf ../supervisor_bak/test3.conf ./supervisor/.
+ ./tool.sh reload
Added Groups: test2,test1
Changed Groups: test3
Removed Groups: test4
+ sleep 3
+ ./tool.sh shutdown
Shut Down
+ rm -rf ./supervisor/test1.conf ./supervisor/test2.conf ./supervisor/test3.conf
```