### PR TITLE
fix index out of range when parsing empty env

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -346,6 +346,11 @@ func parseEnv(s string) *map[string]string {
 		for i = start; i < n && s[i] != '='; {
 			i++
 		}
+
+		if start >= n || i+1 >= n {
+			break
+		}
+
 		key := s[start:i]
 		start = i + 1
 		if s[start] == '"' {

--- a/process/process.go
+++ b/process/process.go
@@ -224,7 +224,9 @@ func (p *Process) GetDescription() string {
 		}
 		return fmt.Sprintf("pid %d, uptime %d:%02d:%02d", p.cmd.Process.Pid, hours%24, minutes%60, seconds%60)
 	} else if p.state != Stopped {
-		return p.stopTime.String()
+                if p.stopTime.Unix() > 0 {
+			return p.stopTime.String()
+		}
 	}
 	return ""
 }


### PR DESCRIPTION
parseEnv in config.go will panic if `s` is empty. 
eg:

```
	envs = parseEnv("")
	envs = parseEnv("A")
	envs = parseEnv("A=")
```

fix with index check