### PR TITLE
set p.inStart to false, after a program was started

### DIFF
--- a/process/process.go
+++ b/process/process.go
@@ -519,6 +519,7 @@ func (p *Process) monitorProgramIsRunning(endTime time.Time, monitorExited *int3
 	// if the program does not exit
 	if atomic.LoadInt32(programExited) == 0 && p.state == Starting {
 		log.WithFields(log.Fields{"program": p.GetName()}).Info("success to start program")
+		p.inStart = false
 		p.changeStateTo(Running)
 	}
 }
@@ -609,6 +610,7 @@ func (p *Process) run(finishCb func()) {
 		// running for any particular amount of time.
 		if startSecs <= 0 {
 			log.WithFields(log.Fields{"program": p.GetName()}).Info("success to start program")
+			p.inStart = false
 			p.changeStateTo(Running)
 			go finishCbWrapper()
 		} else {


### PR DESCRIPTION
this should fix bugs when a process is stopped and then started but fails because the flag was still in "starting"