### PR TITLE
fix(log): remove useless println

### DIFF
--- a/xmlrpc.go
+++ b/xmlrpc.go
@@ -3,7 +3,6 @@ package main
 import (
 	"crypto/sha1" //nolint:gosec
 	"encoding/hex"
-	"fmt"
 	"io"
 	"io/ioutil"
 	"net"
@@ -189,7 +188,6 @@ func (p *XMLRPC) startHTTPServer(user string, password string, protocol string, 
 			continue
 		}
 		dir := filepath.Dir(filePath)
-		fmt.Println(dir)
 		mux.Handle("/log/"+realName+"/", http.StripPrefix("/log/"+realName+"/", http.FileServer(http.Dir(dir))))
 	}
 


### PR DESCRIPTION
Hello !

I encountered this issue while running supervisord with the env variable `LOG_FORMAT=json` :

```toml
[program:workload]
command = /bin/bash -c "sleep 110000"
stdout_logfile = /dev/stdout
stderr_logfile = /dev/stderr

[inet_http_server]
port=0.0.0.0:1025
username=test
password=test
```

```
{"file":"/supervisor.conf","level":"info","msg":"load configuration from file","time":"2024-12-10T09:11:30Z"}
/dev
```

The debug print was not in json and I believe may have been used for debugging purpose.