### PR TITLE
fix: require authentication for the log directory endpoint

### DIFF
--- a/xmlrpc.go
+++ b/xmlrpc.go
@@ -188,7 +188,9 @@ func (p *XMLRPC) startHTTPServer(user string, password string, protocol string, 
 			continue
 		}
 		dir := filepath.Dir(filePath)
-		mux.Handle("/log/"+realName+"/", http.StripPrefix("/log/"+realName+"/", http.FileServer(http.Dir(dir))))
+		prefix := "/log/" + realName + "/"
+		mux.Handle(prefix, newHTTPBasicAuth(user, password,
+			http.StripPrefix(prefix, http.FileServer(http.Dir(dir)))))
 	}
 
 	listener, err := net.Listen(protocol, listenAddr)


### PR DESCRIPTION
### Problem

Every route registered in `startHTTPServer` (`xmlrpc.go`) is wrapped in
`newHTTPBasicAuth`, except the per-program log endpoint:

    mux.Handle("/log/"+realName+"/", http.StripPrefix("/log/"+realName+"/", http.FileServer(http.Dir(dir))))

`http.ServeMux` dispatches to the most specific matching pattern, so this route
shadows the authenticated `"/"` catch-all rather than falling through to it. The
endpoint is therefore served without credentials even when `username` and
`password` are configured in `[inet_http_server]`.

Two things make the impact wider than the log file itself:

- the handler serves `filepath.Dir(stdout_logfile)`, so every file that happens
  to sit in that directory is reachable, not only the configured log;
- `http.FileServer` follows symlinks, so a symlink inside that directory reaches
  outside of it.

Log files routinely contain tokens, stack traces and request data, so this is an
unauthenticated information disclosure on any deployment that reaches the
network.

### Fix

Wrap the handler in `newHTTPBasicAuth` like every other route. The repeated
prefix is lifted into a variable so that it is not spelled three times.

### Verification

- `/log/<program>/` returns 401 without credentials and 200 with them.
- The other endpoints and the XML-RPC interface are unaffected.
- `go build ./...` and `go test ./...` pass. The pre-existing `go vet` findings
  in `rlimit.go` and `ctl.go` are unchanged.

### Notes

This is the minimal fix for the authentication gap. Serving the whole directory
is still broader than necessary: restricting the handler to the configured
`stdout_logfile` / `stderr_logfile` would remove the directory listing and the
symlink traversal as well, but that is a behaviour change and is left out of
this PR.

Fixes for related findings in the same area (unauthenticated `/metrics`, unix
socket permissions, CSRF on the REST interface, XSS in the web GUI) are prepared
separately and can follow once this lands.
