### PR TITLE
fix: replace ioutil.ReadAll with io.ReadAll in xmlrpc.go

### DIFF
--- a/xmlrpc.go
+++ b/xmlrpc.go
@@ -137,7 +137,7 @@ func readLogHtml(writer http.ResponseWriter, request *http.Request) {
 		file, err = HTTP.Open("log.html")
 		if err == nil {
 			defer file.Close()
-			b, err = ioutil.ReadAll(file)
+			b, err = io.ReadAll(file)
 		}
 	} else {
 		b, err = readFile("webgui/log.html")


### PR DESCRIPTION
### Description
A recent commit partially reverted the migration from `io/ioutil` to `io` in `xmlrpc.go`, causing an `undefined: ioutil` compilation error because `ioutil` is missing from the imports (and deprecated/removed in newer Go versions).

### Changes
- Replaced `ioutil.ReadAll` with `io.ReadAll` in `xmlrpc.go` to restore successful compilation.
